### PR TITLE
Update PWM frequency range to match hardware spec

### DIFF
--- a/Source/CS01AudioProcessor.cpp
+++ b/Source/CS01AudioProcessor.cpp
@@ -349,7 +349,7 @@ juce::AudioProcessorValueTreeState::ParameterLayout CS01AudioProcessor::createPa
         "vco", "VCO", "|",
         std::make_unique<juce::AudioParameterChoice>(ParameterIds::waveType, "Wave Type", juce::StringArray{"Triangle", "Sawtooth", "Square", "Pulse", "PWM"}, 1),
         std::make_unique<juce::AudioParameterChoice>(ParameterIds::feet, "Feet", juce::StringArray{"32'", "16'", "8'", "4'", "WN"}, 2),
-        std::make_unique<juce::AudioParameterFloat>(ParameterIds::pwmSpeed, "PWM Speed", juce::NormalisableRange<float>(0.6f, 12.0f, 0.01f, 0.5f), 2.0f),
+        std::make_unique<juce::AudioParameterFloat>(ParameterIds::pwmSpeed, "PWM Speed", juce::NormalisableRange<float>(0.0f, 60.0f, 0.01f, 0.25f), 2.0f),
         std::make_unique<juce::AudioParameterFloat>(ParameterIds::pitch, "Pitch", juce::NormalisableRange<float>(-1.0f, 1.0f, 0.01f), 0.0f),
         std::make_unique<juce::AudioParameterFloat>(ParameterIds::glissando, "Glissando", juce::NormalisableRange<float>(0.0f, Constants::maxGlissandoPerSemitoneSeconds, 0.001f, 0.5f), 0.0f)
     );

--- a/Source/CS01Synth/ToneGenerator.cpp
+++ b/Source/CS01Synth/ToneGenerator.cpp
@@ -132,7 +132,11 @@ void ToneGenerator::updateBlockRateParameters()
 {
     currentFeet = static_cast<Feet>(static_cast<int>(*apvts.getRawParameterValue(ParameterIds::feet)));
     currentWaveform = static_cast<Waveform>(static_cast<int>(*apvts.getRawParameterValue(ParameterIds::waveType)));
-    pwmLfo.setFrequency(apvts.getRawParameterValue(ParameterIds::pwmSpeed)->load());
+    
+    // PWM LFO frequency setting with hardware-accurate range (0-60Hz)
+    float pwmSpeed = apvts.getRawParameterValue(ParameterIds::pwmSpeed)->load();
+    pwmLfo.setFrequency(pwmSpeed);
+    
     currentModDepth = apvts.getRawParameterValue(ParameterIds::modDepth)->load();
 }
 


### PR DESCRIPTION
- Expand PWM frequency range from 0.6-12Hz to 0-60Hz 
- Adjust skewFactor to match C500K potentiometer curve