### PR TITLE
Optimize audio processing memory allocation in VCF processors

### DIFF
--- a/Source/CS01Synth/CS01VCFProcessor.h
+++ b/Source/CS01Synth/CS01VCFProcessor.h
@@ -47,6 +47,7 @@ private:
     //==============================================================================
     juce::AudioProcessorValueTreeState& apvts;
     IG02610LPF filter; // Using IG02610LPF instead of StateVariableTPTFilter
+    juce::HeapBlock<float> cutoffModulationBuffer; // バッファを事前に確保して再利用
     
     // Cutoff frequency mapping function
     float mapCutoffFrequency(float cutoffParam)

--- a/Source/CS01Synth/ModernVCFProcessor.h
+++ b/Source/CS01Synth/ModernVCFProcessor.h
@@ -47,6 +47,7 @@ private:
     //==============================================================================
     juce::AudioProcessorValueTreeState& apvts;
     std::vector<juce::dsp::StateVariableTPTFilter<float>> filters; // Filter for each channel
+    std::vector<juce::AudioBuffer<float>> tempBuffers; // Reusable temporary buffers for audio processing
     
     // Cutoff frequency mapping function
     float mapCutoffFrequency(float cutoffParam)


### PR DESCRIPTION
- Pre-allocate and reuse temporary buffers in ModernVCFProcessor
- Pre-allocate and reuse HeapBlock in CS01VCFProcessor
- Avoid dynamic memory allocation in real-time audio thread