### PR TITLE
Improve variable and method names for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,16 @@ CheapSynth01 uses JUCE's AudioProcessorGraph to implement a modular synthesis ar
 ```mermaid
 graph TD
     MIDI[MIDI Input] --> MidiProc[MIDI Processor]
-    MidiProc --> |ISoundGenerator| VCO[VCO Processor]
+    MidiProc --> |Uses| VCO[VCO Processor]
     MidiProc --> |Triggers| EG[Envelope Generator]
     
     subgraph "VCO Processor"
         VCO --> |manages| GenSwitch{Generator Type}
         GenSwitch --> |Tone| ToneGen[Tone Generator]
         GenSwitch --> |Noise| NoiseGen[Noise Generator]
+        ToneGen --> |implements| ISG[ISoundGenerator]
+        NoiseGen --> |implements| ISG
+        ISG --> |provided to| MidiProc
     end
     
     VCO --> |Audio| FilterSwitch{Filter Type}

--- a/Source/CS01AudioProcessor.cpp
+++ b/Source/CS01AudioProcessor.cpp
@@ -87,19 +87,19 @@ void CS01AudioProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
     audioGraph.addConnection({{midiInputNode->nodeID, juce::AudioProcessorGraph::midiChannelIndex},
                               {midiProcessorNode->nodeID, juce::AudioProcessorGraph::midiChannelIndex}});
                               
-    // Set references to NoteHandler and EGProcessor in MidiProcessor
+    // Set references to SoundGenerator and EGProcessor in MidiProcessor
     auto* midiProcessor = static_cast<MidiProcessor*>(midiProcessorNode->getProcessor());
-    auto* synthProcessor = static_cast<VCOProcessor*>(vcoNode->getProcessor());
+    auto* vcoProcessor = static_cast<VCOProcessor*>(vcoNode->getProcessor());
     auto* egProcessor = static_cast<EGProcessor*>(egNode->getProcessor());
     
-    if (midiProcessor != nullptr && synthProcessor != nullptr && egProcessor != nullptr)
+    if (midiProcessor != nullptr && vcoProcessor != nullptr && egProcessor != nullptr)
     {
-        // Set the note handler
-        midiProcessor->setNoteHandler(synthProcessor->getNoteHandler());
+        // Set the sound generator
+        midiProcessor->setSoundGenerator(vcoProcessor->getSoundGenerator());
         midiProcessor->setEGProcessor(egProcessor);
         
         // Set up VCO generator type change callback
-        synthProcessor->onGeneratorTypeChanged = [this]() {
+        vcoProcessor->onGeneratorTypeChanged = [this]() {
             handleGeneratorTypeChanged();
         };
     }
@@ -314,13 +314,13 @@ void CS01AudioProcessor::handleGeneratorTypeChanged()
         return;
     }
 
-    // Update the MidiProcessor's note handler reference
+    // Update the MidiProcessor's sound generator reference
     auto* midiProcessor = static_cast<MidiProcessor*>(midiProcessorNode->getProcessor());
     auto* vcoProcessor = static_cast<VCOProcessor*>(vcoNode->getProcessor());
     
     if (midiProcessor != nullptr && vcoProcessor != nullptr)
     {
-        midiProcessor->setNoteHandler(vcoProcessor->getNoteHandler());
+        midiProcessor->setSoundGenerator(vcoProcessor->getSoundGenerator());
     }
 }
 
@@ -349,7 +349,7 @@ void CS01AudioProcessor::parameterChanged(const juce::String& parameterID, float
         // Reconnect based on the new value
         if (static_cast<int>(newValue) == 0) // Target: VCO
         {
-            // Connect LFO to SynthProcessor's LFO input (bus 0)
+            // Connect LFO to VCOProcessor's LFO input (bus 0)
             audioGraph.addConnection({ {lfoNode->nodeID, 0}, {vcoNode->nodeID, 0} });
         }
         else // Target: VCF

--- a/Source/CS01Synth/CS01VCFProcessor.h
+++ b/Source/CS01Synth/CS01VCFProcessor.h
@@ -47,10 +47,10 @@ private:
     //==============================================================================
     juce::AudioProcessorValueTreeState& apvts;
     IG02610LPF filter; // Using IG02610LPF instead of StateVariableTPTFilter
-    juce::HeapBlock<float> cutoffModulationBuffer; // バッファを事前に確保して再利用
+    juce::HeapBlock<float> modulationBuffer; // バッファを事前に確保して再利用
     
-    // Cutoff frequency mapping function
-    float mapCutoffFrequency(float cutoffParam)
+    // Cutoff frequency calculation function
+    float calculateCutoffFrequency(float cutoffParam)
     {
         // Range covering the entire audible spectrum
         const float minFreq = 20.0f;  // Minimum cutoff frequency
@@ -62,8 +62,8 @@ private:
         return cutoffFreq;
     }
     
-    // Resonance mapping function
-    float mapResonance(bool isHighResonance)
+    // Resonance calculation function
+    float calculateResonance(bool isHighResonance)
     {
         // Simple resonance value based on switch state
         if (isHighResonance)

--- a/Source/CS01Synth/EGProcessor.cpp
+++ b/Source/CS01Synth/EGProcessor.cpp
@@ -43,7 +43,7 @@ void EGProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuff
     buffer.clear();
 
     // Skip MIDI message processing (already processed in MidiProcessor)
-    // MIDI messages are processed by triggerNoteOn/triggerNoteOff methods
+    // MIDI messages are processed by startEnvelope/releaseEnvelope methods
 
     // Process only a single channel as output is mono
     auto* channelData = buffer.getWritePointer(0);

--- a/Source/CS01Synth/EGProcessor.h
+++ b/Source/CS01Synth/EGProcessor.h
@@ -22,8 +22,8 @@ public:
     bool isActive() const { return adsr.isActive(); }
     
     // Methods to control ADSR from outside
-    void triggerNoteOn() { adsr.noteOn(); }
-    void triggerNoteOff() { adsr.noteOff(); }
+    void startEnvelope() { adsr.noteOn(); }
+    void releaseEnvelope() { adsr.noteOff(); }
 
     //==============================================================================
     juce::AudioProcessorEditor* createEditor() override { return nullptr; }

--- a/Source/CS01Synth/MidiProcessor.cpp
+++ b/Source/CS01Synth/MidiProcessor.cpp
@@ -59,21 +59,21 @@ void MidiProcessor::handleNoteOn(const juce::MidiMessage& midiMessage)
     int highestNote = activeNotes.getLast();
     float velocity = midiMessage.getVelocity() / 127.0f;
 
-    if (noteHandler != nullptr)
+    if (soundGenerator != nullptr)
     {
         if (wasEmpty)
         {
-            noteHandler->startNote(highestNote, velocity, lastPitchWheelValue);
+            soundGenerator->startNote(highestNote, velocity, lastPitchWheelValue);
             
             // Call EG note-on only for the first note
             if (egProcessor != nullptr)
             {
-                egProcessor->triggerNoteOn();
+                egProcessor->startEnvelope();
             }
         }
         else
         {
-            noteHandler->changeNote(highestNote);
+            soundGenerator->changeNote(highestNote);
         }
     }
 }
@@ -82,24 +82,24 @@ void MidiProcessor::handleNoteOff(const juce::MidiMessage& midiMessage)
 {
     activeNotes.removeFirstMatchingValue(midiMessage.getNoteNumber());
     
-    if (noteHandler != nullptr)
+    if (soundGenerator != nullptr)
     {
         if (activeNotes.isEmpty())
         {
             // Always set allowTailOff = true to make sound fade gradually
-            noteHandler->stopNote(true);
+            soundGenerator->stopNote(true);
             
             // Start EG release only when all notes are off
             if (egProcessor != nullptr)
             {
-                egProcessor->triggerNoteOff();
+                egProcessor->releaseEnvelope();
             }
         }
         else
         {
             activeNotes.sort();
             int highestNote = activeNotes.getLast();
-            noteHandler->changeNote(highestNote);
+            soundGenerator->changeNote(highestNote);
         }
     }
 }
@@ -108,10 +108,10 @@ void MidiProcessor::handlePitchWheel(const juce::MidiMessage& midiMessage)
 {
     lastPitchWheelValue = midiMessage.getPitchWheelValue();
     
-    // Set pitch wheel value to note handler
-    if (noteHandler != nullptr)
+    // Set pitch wheel value to sound generator
+    if (soundGenerator != nullptr)
     {
-        noteHandler->pitchWheelMoved(lastPitchWheelValue);
+        soundGenerator->pitchWheelMoved(lastPitchWheelValue);
     }
     
     // Also set pitch bend value to parameter

--- a/Source/CS01Synth/MidiProcessor.h
+++ b/Source/CS01Synth/MidiProcessor.h
@@ -30,8 +30,8 @@ public:
     void getStateInformation(juce::MemoryBlock&) override {}
     void setStateInformation(const void*, int) override {}
 
-    // Set note handler
-    void setNoteHandler(ISoundGenerator* handler) { noteHandler = handler; }
+    // Set sound generator
+    void setSoundGenerator(ISoundGenerator* generator) { soundGenerator = generator; }
     
     // Set EG processor
     void setEGProcessor(EGProcessor* processor) { egProcessor = processor; }
@@ -39,8 +39,8 @@ public:
     // Get currently playing note
     int getCurrentlyPlayingNote() const { return activeNotes.isEmpty() ? 0 : activeNotes.getLast(); }
     
-    // Get note handler
-    ISoundGenerator* getNoteHandler() const { return noteHandler; }
+    // Get sound generator
+    ISoundGenerator* getSoundGenerator() const { return soundGenerator; }
     
     // Get array of active notes
     const juce::Array<int>& getActiveNotes() const { return activeNotes; }
@@ -54,7 +54,7 @@ private:
     void handleControllerMessage(const juce::MidiMessage& midiMessage);
 
     juce::AudioProcessorValueTreeState& apvts;
-    ISoundGenerator* noteHandler = nullptr;
+    ISoundGenerator* soundGenerator = nullptr;
     EGProcessor* egProcessor = nullptr;
     
     // For monophonic sound management

--- a/Source/CS01Synth/ModernVCFProcessor.h
+++ b/Source/CS01Synth/ModernVCFProcessor.h
@@ -47,10 +47,10 @@ private:
     //==============================================================================
     juce::AudioProcessorValueTreeState& apvts;
     std::vector<juce::dsp::StateVariableTPTFilter<float>> filters; // Filter for each channel
-    std::vector<juce::AudioBuffer<float>> tempBuffers; // Reusable temporary buffers for audio processing
+    std::vector<juce::AudioBuffer<float>> processingBuffers; // Reusable buffers for audio processing
     
-    // Cutoff frequency mapping function
-    float mapCutoffFrequency(float cutoffParam)
+    // Cutoff frequency calculation function
+    float calculateCutoffFrequency(float cutoffParam)
     {
         // Range covering the entire audible spectrum
         const float minFreq = 20.0f;  // Minimum cutoff frequency
@@ -62,8 +62,8 @@ private:
         return cutoffFreq;
     }
     
-    // Resonance mapping function
-    float mapResonance(bool isHighResonance)
+    // Resonance calculation function
+    float calculateResonance(bool isHighResonance)
     {
         // Simple resonance value based on switch state
         if (isHighResonance)

--- a/Source/CS01Synth/VCOProcessor.h
+++ b/Source/CS01Synth/VCOProcessor.h
@@ -43,23 +43,20 @@ public:
     // AudioProcessorValueTreeState::Listener implementation
     void parameterChanged(const juce::String& parameterID, float newValue) override;
 
-    // Accessor for active ISoundGenerator
-    ISoundGenerator* getActiveGenerator() { return activeGenerator; }
-    
-    // Accessor for note handler interface
-    ISoundGenerator* getNoteHandler() { return activeGenerator; }
+    // Accessor for sound generator interface
+    ISoundGenerator* getSoundGenerator() { return currentGenerator; }
     
     // Method to notify when generator type changes (for external use)
     std::function<void()> onGeneratorTypeChanged;
     
     // Check if noise generator is active
-    bool isNoiseMode() const { return activeGenerator == noiseGenerator.get(); }
+    bool isNoiseMode() const { return currentGenerator == noiseGenerator.get(); }
 
 private:
     juce::AudioProcessorValueTreeState& apvts;
     std::unique_ptr<ToneGenerator> toneGenerator;
     std::unique_ptr<NoiseGenerator> noiseGenerator;
-    ISoundGenerator* activeGenerator; // Pointer to the currently active generator
+    ISoundGenerator* currentGenerator; // Pointer to the currently selected generator
     juce::dsp::ProcessSpec lastSpec;
     bool isPrepared = false;
     float lfoValue = 0.0f;

--- a/Tests/unit/EGProcessorTest.cpp
+++ b/Tests/unit/EGProcessorTest.cpp
@@ -206,7 +206,7 @@ private:
             apvts.getParameter(ParameterIds::release)->convertTo0to1(0.2f)); // 200ms release
         
         // Trigger note on
-        processor->triggerNoteOn();
+        processor->startEnvelope();
         
         // Process block (should generate attack phase)
         buffer.clear();
@@ -234,7 +234,7 @@ private:
         expect(processor->isActive());
         
         // Trigger note off
-        processor->triggerNoteOff();
+        processor->releaseEnvelope();
         
         // Process block (should generate release phase)
         buffer.clear();
@@ -275,13 +275,13 @@ private:
         expect(!processor->isActive());
         
         // Trigger note on
-        processor->triggerNoteOn();
+        processor->startEnvelope();
         
         // Check that envelope is active
         expect(processor->isActive());
         
         // Trigger note off
-        processor->triggerNoteOff();
+        processor->releaseEnvelope();
         
         // Note: We can't check that envelope is inactive immediately after noteOff
         // because the release phase takes time. In a real test, we would process

--- a/Tests/unit/MidiProcessorTest.cpp
+++ b/Tests/unit/MidiProcessorTest.cpp
@@ -90,7 +90,7 @@ private:
         // Check initial state
         expect(processor->getActiveNotes().isEmpty());
         expectEquals(processor->getCurrentlyPlayingNote(), 0);
-        expect(processor->getNoteHandler() == nullptr);
+        expect(processor->getSoundGenerator() == nullptr);
     }
     
     void testNoteOnOff()
@@ -107,9 +107,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Create EGProcessor
         std::unique_ptr<EGProcessor> egProcessor = std::make_unique<EGProcessor>(apvts);
@@ -161,9 +161,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Create audio buffer and MIDI buffer
         juce::AudioBuffer<float> buffer(1, 512);
@@ -246,9 +246,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Create audio buffer and MIDI buffer
         juce::AudioBuffer<float> buffer(1, 512);
@@ -314,9 +314,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Create audio buffer and MIDI buffer
         juce::AudioBuffer<float> buffer(1, 512);
@@ -504,9 +504,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Set very short attack, decay and release times for testing
         auto attackParam = static_cast<juce::AudioParameterFloat*>(apvts.getParameter(ParameterIds::attack));
@@ -618,9 +618,9 @@ private:
         // Create MidiProcessor
         std::unique_ptr<MidiProcessor> processor = std::make_unique<MidiProcessor>(apvts);
         
-        // Create mock tone generator as note handler
+        // Create mock tone generator as sound generator
         testing::MockToneGenerator mockToneGenerator(apvts);
-        processor->setNoteHandler(&mockToneGenerator);
+        processor->setSoundGenerator(&mockToneGenerator);
         
         // Create audio buffer and MIDI buffer
         juce::AudioBuffer<float> buffer(1, 512);

--- a/Tests/unit/VCOProcessorTest.cpp
+++ b/Tests/unit/VCOProcessorTest.cpp
@@ -178,7 +178,7 @@ private:
             expect(processor != nullptr);
             
             // Check if ISoundGenerator interface can be obtained
-            ISoundGenerator* noteHandler = processor->getNoteHandler();
+            ISoundGenerator* noteHandler = processor->getSoundGenerator();
             expect(noteHandler != nullptr);
             
             // No further operations (especially no processBlock call)
@@ -238,7 +238,7 @@ private:
             }
             
             // 6. Note handler test
-            auto* noteHandler = processor.getNoteHandler();
+            auto* noteHandler = processor.getSoundGenerator();
             expect(noteHandler != nullptr);
             
             // API call verification only
@@ -305,7 +305,7 @@ private:
             }
             
             // 5. Note handler API test
-            auto* noteHandler = processor.getNoteHandler();
+            auto* noteHandler = processor.getSoundGenerator();
             expect(noteHandler != nullptr);
             
             if (noteHandler) {
@@ -381,7 +381,7 @@ private:
             
             // 3. Test VCOProcessor creation and note handler API
             VCOProcessor processor(apvts);
-            auto* noteHandler = processor.getNoteHandler();
+            auto* noteHandler = processor.getSoundGenerator();
             expect(noteHandler != nullptr);
             
             if (noteHandler) {
@@ -460,7 +460,7 @@ private:
                 feetParam->setValueNotifyingHost(feetParam->convertTo0to1(2)); // 8'
             
             // 8. Start note
-            auto* noteHandler = processor.getNoteHandler();
+            auto* noteHandler = processor.getSoundGenerator();
             expect(noteHandler != nullptr);
             
             noteHandler->startNote(69, 1.0f, 8192); // A4 (440Hz)


### PR DESCRIPTION
- Rename activeGenerator to currentGenerator in VCOProcessor
- Remove duplicate getActiveGenerator method
- Rename triggerNoteOn/Off to startEnvelope/releaseEnvelope in EGProcessor
- Rename cutoffModulationBuffer to modulationBuffer in CS01VCFProcessor
- Rename mapCutoffFrequency/mapResonance to calculateCutoffFrequency/calculateResonance
- Rename tempBuffers to processingBuffers in ModernVCFProcessor
- Update README diagram to fix ISoundGenerator relationship