### PR TITLE
Implement continuous resonance control for ModernVCFProcessor and upd…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,7 +143,7 @@ target_sources(CheapSynth01
         Source/UI/VolumeComponent.cpp
         Source/UI/OscilloscopeComponent.cpp
         Source/CS01Synth/ToneGenerator.cpp
-        Source/CS01Synth/CS01VCFProcessor.cpp
+        Source/CS01Synth/OriginalVCFProcessor.cpp
         Source/CS01Synth/VCAProcessor.cpp
         Source/CS01Synth/VCOProcessor.cpp
         Source/CS01Synth/MidiProcessor.cpp

--- a/Source/CS01AudioProcessor.h
+++ b/Source/CS01AudioProcessor.h
@@ -2,18 +2,21 @@
 
 #include <JuceHeader.h>
 #include "ProgramManager.h"
+#include "CS01Synth/IFilter.h"
 #include "CS01Synth/VCOProcessor.h"
 #include "CS01Synth/MidiProcessor.h"
 #include "CS01Synth/EGProcessor.h"
 #include "CS01Synth/LFOProcessor.h"
 #include "CS01Synth/VCAProcessor.h"
-#include "CS01Synth/CS01VCFProcessor.h"
+#include "CS01Synth/OriginalVCFProcessor.h"
 #include "CS01Synth/ModernVCFProcessor.h"
 
 class CS01AudioProcessor  : public juce::AudioProcessor,
                             public juce::AudioProcessorValueTreeState::Listener
 {
 public:
+    // Get current filter processor
+    IFilter* getCurrentFilterProcessor();
     //==============================================================================
     CS01AudioProcessor();
     ~CS01AudioProcessor() override;

--- a/Source/CS01AudioProcessorEditor.cpp
+++ b/Source/CS01AudioProcessorEditor.cpp
@@ -1,6 +1,7 @@
 #include "CS01AudioProcessor.h"
 #include "CS01AudioProcessorEditor.h"
 #include "UI/CS01LookAndFeel.h"
+#include "CS01Synth/IFilter.h"
 
 // Use JUCE namespace
 using namespace juce;
@@ -97,4 +98,15 @@ void CS01AudioProcessorEditor::paint(juce::Graphics& g)
 void CS01AudioProcessorEditor::resized()
 {
     mainFlex.performLayout(getLocalBounds().reduced(10));
+}
+
+// Called when filter type changes
+void CS01AudioProcessorEditor::filterTypeChanged(IFilter* newFilterProcessor)
+{
+    // Get resonance control type from IFilterProcessor
+    if (newFilterProcessor != nullptr && vcfComponent != nullptr)
+    {
+        // Notify VCFComponent about filter type change
+        vcfComponent->updateFilterControl(newFilterProcessor);
+    }
 }

--- a/Source/CS01AudioProcessorEditor.h
+++ b/Source/CS01AudioProcessorEditor.h
@@ -1,7 +1,9 @@
 #pragma once
 
 #include <JuceHeader.h>
-#include "CS01AudioProcessor.h"
+// 循環参照を避けるために前方宣言
+class CS01AudioProcessor;
+class IFilter;
 #include "UI/ModulationComponent.h"
 #include "UI/VCOComponent.h"
 #include "UI/LFOComponent.h"
@@ -26,6 +28,9 @@ public:
 
     void paint(juce::Graphics&) override;
     void resized() override;
+    
+    // フィルタータイプが変更されたときに呼び出される
+    void filterTypeChanged(IFilter* newFilterProcessor);
     
     OscilloscopeComponent& getOscilloscope() { return oscilloscopeComponent; }
     juce::AudioVisualiserComponent& getAudioVisualiser() { return audioVisualiser; }

--- a/Source/CS01Synth/IFilter.h
+++ b/Source/CS01Synth/IFilter.h
@@ -1,0 +1,26 @@
+#pragma once
+
+/**
+ * Common interface for filters
+ * Provides information about filter-specific behaviors
+ */
+class IFilter
+{
+public:
+    // Resonance mode enumeration
+    enum class ResonanceMode {
+        Toggle,     // Toggle control (Original)
+        Continuous  // Continuous value control (Modern)
+    };
+    
+    // Virtual destructor
+    virtual ~IFilter() = default;
+    
+    // Pure virtual function to get resonance mode
+    virtual ResonanceMode getResonanceMode() const = 0;
+    
+    // Other filter-related methods that can be extended in the future
+    // virtual FilterType getFilterType() const = 0;
+    // virtual int getFilterOrder() const = 0;
+    // etc...
+};

--- a/Source/CS01Synth/ModernVCFProcessor.h
+++ b/Source/CS01Synth/ModernVCFProcessor.h
@@ -2,10 +2,11 @@
 
 #include <JuceHeader.h>
 #include "../Parameters.h"
+#include "IFilter.h" // Interface
 
 //==============================================================================
 // ModernVCFProcessor - Filter using JUCE's StateVariableTPTFilter (with less distortion)
-class ModernVCFProcessor  : public juce::AudioProcessor
+class ModernVCFProcessor  : public juce::AudioProcessor, public IFilter
 {
 public:
     //==============================================================================
@@ -42,6 +43,12 @@ public:
     //==============================================================================
     void getStateInformation (juce::MemoryBlock& destData) override {}
     void setStateInformation (const void* data, int sizeInBytes) override {}
+    
+    // Implementation of IFilter interface
+    ResonanceMode getResonanceMode() const override 
+    { 
+        return ResonanceMode::Continuous;
+    }
 
 private:
     //==============================================================================
@@ -63,19 +70,11 @@ private:
     }
     
     // Resonance calculation function
-    float calculateResonance(bool isHighResonance)
+    float calculateResonance(float resonanceParam)
     {
-        // Simple resonance value based on switch state
-        if (isHighResonance)
-        {
-            // High resonance setting
-            return 0.8f;
-        }
-        else
-        {
-            // Low resonance setting
-            return 0.2f;
-        }
+        // Map normalized input (0.0 - 1.0) to useful resonance range
+        // Resonance for StateVariableTPTFilter is effective in the range of 0.1 to 0.9
+        return 0.1f + (resonanceParam * 0.8f);  // Map to range 0.1 to 0.9
     }
     
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (ModernVCFProcessor)

--- a/Source/CS01Synth/OriginalVCFProcessor.cpp
+++ b/Source/CS01Synth/OriginalVCFProcessor.cpp
@@ -1,7 +1,7 @@
-#include "CS01VCFProcessor.h"
+#include "OriginalVCFProcessor.h"
 
 //==============================================================================
-CS01VCFProcessor::CS01VCFProcessor(juce::AudioProcessorValueTreeState& apvts)
+OriginalVCFProcessor::OriginalVCFProcessor(juce::AudioProcessorValueTreeState& apvts)
     : AudioProcessor (BusesProperties()
                           .withInput  ("AudioInput",  juce::AudioChannelSet::mono(), true)
                           .withInput  ("EGInput", juce::AudioChannelSet::mono(), true)
@@ -11,12 +11,12 @@ CS01VCFProcessor::CS01VCFProcessor(juce::AudioProcessorValueTreeState& apvts)
 {
 }
 
-CS01VCFProcessor::~CS01VCFProcessor()
+OriginalVCFProcessor::~OriginalVCFProcessor()
 {
 }
 
 //==============================================================================
-void CS01VCFProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
+void OriginalVCFProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
 {
     // Initialize filter
     filter.reset();
@@ -26,13 +26,13 @@ void CS01VCFProcessor::prepareToPlay (double sampleRate, int samplesPerBlock)
     modulationBuffer.allocate(samplesPerBlock, true);
 }
 
-void CS01VCFProcessor::releaseResources()
+void OriginalVCFProcessor::releaseResources()
 {
     // Reset filter
     filter.reset();
 }
 
-bool CS01VCFProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
+bool OriginalVCFProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
 {
     const auto& mainIn = layouts.getChannelSet(true, 0);
     const auto& egIn   = layouts.getChannelSet(true, 1);
@@ -47,11 +47,11 @@ bool CS01VCFProcessor::isBusesLayoutSupported (const BusesLayout& layouts) const
     return true;
 }
 
-void CS01VCFProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
+void OriginalVCFProcessor::processBlock (juce::AudioBuffer<float>& buffer, juce::MidiBuffer& midiMessages)
 {
     juce::ScopedNoDenormals noDenormals;
 
-    // CS01 is completely mono, so only process channel 0
+    // Original filter is completely mono, so only process channel 0
     auto audioInput = getBusBuffer(buffer, true, 0);
     auto egInput = getBusBuffer(buffer, true, 1);
     auto lfoInput = getBusBuffer(buffer, true, 2);

--- a/Source/CS01Synth/OriginalVCFProcessor.h
+++ b/Source/CS01Synth/OriginalVCFProcessor.h
@@ -3,14 +3,15 @@
 #include <JuceHeader.h>
 #include "../Parameters.h"
 #include "IG02610LPF.h" // Include the IG02610LPF filter
+#include "IFilter.h" // Updated interface
 
 //==============================================================================
-class CS01VCFProcessor  : public juce::AudioProcessor
+class OriginalVCFProcessor  : public juce::AudioProcessor, public IFilter
 {
 public:
     //==============================================================================
-    CS01VCFProcessor(juce::AudioProcessorValueTreeState& apvts);
-    ~CS01VCFProcessor() override;
+    OriginalVCFProcessor(juce::AudioProcessorValueTreeState& apvts);
+    ~OriginalVCFProcessor() override;
 
     //==============================================================================
     void prepareToPlay (double sampleRate, int samplesPerBlock) override;
@@ -25,7 +26,7 @@ public:
     bool hasEditor() const override { return false; }
 
     //==============================================================================
-    const juce::String getName() const override { return "VCF"; }
+    const juce::String getName() const override { return "Original VCF"; }
 
     bool acceptsMidi() const override { return false; }
     bool producesMidi() const override { return false; }
@@ -42,6 +43,12 @@ public:
     //==============================================================================
     void getStateInformation (juce::MemoryBlock& destData) override {}
     void setStateInformation (const void* data, int sizeInBytes) override {}
+    
+    // Implementation of IFilter interface
+    ResonanceMode getResonanceMode() const override 
+    { 
+        return ResonanceMode::Toggle;
+    }
 
 private:
     //==============================================================================
@@ -63,10 +70,11 @@ private:
     }
     
     // Resonance calculation function
-    float calculateResonance(bool isHighResonance)
+    float calculateResonance(float resonanceParam)
     {
-        // Simple resonance value based on switch state
-        if (isHighResonance)
+        // For original filter, use threshold to binarize the value
+        // Treat as High Resonance if value is 0.5 or higher
+        if (resonanceParam >= 0.5f)
         {
             // High resonance setting - IG02610LPF has max resonance of 0.8f
             return 0.7f;
@@ -78,5 +86,5 @@ private:
         }
     }
     
-    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (CS01VCFProcessor)
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (OriginalVCFProcessor)
 };

--- a/Source/Resources/Presets/Clavinet.xml
+++ b/Source/Resources/Presets/Clavinet.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="12000.0"/>
-  <PARAM id="RESONANCE" value="0"/>
+  <PARAM id="RESONANCE" value="0.25"/>
   <PARAM id="VCF_EG_DEPTH" value="0.8"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="0.001"/>

--- a/Source/Resources/Presets/Default.xml
+++ b/Source/Resources/Presets/Default.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="20000.0"/>
-  <PARAM id="RESONANCE" value="0"/>
+  <PARAM id="RESONANCE" value="0.3"/>
   <PARAM id="VCF_EG_DEPTH" value="0.0"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="0.1"/>

--- a/Source/Resources/Presets/Flute.xml
+++ b/Source/Resources/Presets/Flute.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="3000.0"/>
-  <PARAM id="RESONANCE" value="0"/>
+  <PARAM id="RESONANCE" value="0.35"/>
   <PARAM id="VCF_EG_DEPTH" value="0.6"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="1.2"/>

--- a/Source/Resources/Presets/Solo_Synth_Lead.xml
+++ b/Source/Resources/Presets/Solo_Synth_Lead.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.2"/>
   <PARAM id="CUTOFF" value="20000.0"/>
-  <PARAM id="RESONANCE" value="1"/>
+  <PARAM id="RESONANCE" value="0.8"/>
   <PARAM id="VCF_EG_DEPTH" value="0.7"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="0.3"/>

--- a/Source/Resources/Presets/Synth_Bass.xml
+++ b/Source/Resources/Presets/Synth_Bass.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="2500.0"/>
-  <PARAM id="RESONANCE" value="1"/>
+  <PARAM id="RESONANCE" value="0.65"/>
   <PARAM id="VCF_EG_DEPTH" value="0.6"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="0.001"/>

--- a/Source/Resources/Presets/Trumpet.xml
+++ b/Source/Resources/Presets/Trumpet.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="5000.0"/>
-  <PARAM id="RESONANCE" value="1"/>
+  <PARAM id="RESONANCE" value="0.7"/>
   <PARAM id="VCF_EG_DEPTH" value="0.5"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="0.3"/>

--- a/Source/Resources/Presets/Violin.xml
+++ b/Source/Resources/Presets/Violin.xml
@@ -5,7 +5,7 @@
   <PARAM id="PITCH" value="0.0"/>
   <PARAM id="GLISSANDO" value="0.0"/>
   <PARAM id="CUTOFF" value="8000.0"/>
-  <PARAM id="RESONANCE" value="1"/>
+  <PARAM id="RESONANCE" value="0.75"/>
   <PARAM id="VCF_EG_DEPTH" value="0.7"/>
   <PARAM id="VCA_EG_DEPTH" value="1.0"/>
   <PARAM id="ATTACK" value="1.5"/>

--- a/Source/UI/FilterTypeComponent.cpp
+++ b/Source/UI/FilterTypeComponent.cpp
@@ -3,8 +3,8 @@
 
 FilterTypeComponent::FilterTypeComponent(juce::AudioProcessorValueTreeState& apvts) : valueTreeState(apvts)
 {
-    filterTypeComboBox.addItem("CS01", 1);
-    filterTypeComboBox.addItem("MODERN", 2);
+    filterTypeComboBox.addItem("Original", 1);
+    filterTypeComboBox.addItem("Modern", 2);
     addAndMakeVisible(filterTypeComboBox);
     
     filterTypeAttachment = std::make_unique<juce::AudioProcessorValueTreeState::ComboBoxAttachment>(

--- a/Source/UI/VCFComponent.cpp
+++ b/Source/UI/VCFComponent.cpp
@@ -1,5 +1,6 @@
 #include "VCFComponent.h"
 #include "../Parameters.h"
+#include "../CS01Synth/IFilter.h"
 
 VCFComponent::VCFComponent(juce::AudioProcessorValueTreeState& apvts) : valueTreeState(apvts)
 {
@@ -9,10 +10,18 @@ VCFComponent::VCFComponent(juce::AudioProcessorValueTreeState& apvts) : valueTre
     cutoffLabel.setText("CUTOFF", juce::dontSendNotification);
     addAndMakeVisible(cutoffLabel);
     
+    // Toggle button for CS01 filter resonance
     resonanceButton.setButtonText("RES");
     addAndMakeVisible(resonanceButton);
     resonanceLabel.setText("ON/OFF", juce::dontSendNotification);
     addAndMakeVisible(resonanceLabel);
+    
+    // Slider for Modern filter resonance
+    resonanceSlider.setSliderStyle(juce::Slider::LinearVertical);
+    resonanceSlider.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
+    addChildComponent(resonanceSlider); // Hidden initially
+    resonanceSliderLabel.setText("RESONANCE", juce::dontSendNotification);
+    addChildComponent(resonanceSliderLabel); // Hidden initially
     
     vcfEgDepthSlider.setSliderStyle(juce::Slider::LinearVertical);
     vcfEgDepthSlider.setTextBoxStyle(juce::Slider::NoTextBox, false, 0, 0);
@@ -22,10 +31,18 @@ VCFComponent::VCFComponent(juce::AudioProcessorValueTreeState& apvts) : valueTre
 
     cutoffAttachment = std::make_unique<juce::SliderParameterAttachment>(
         *valueTreeState.getParameter(ParameterIds::cutoff), cutoffSlider);
-    resonanceAttachment = std::make_unique<juce::ButtonParameterAttachment>(
-        *valueTreeState.getParameter(ParameterIds::resonance), resonanceButton);
     vcfEgDepthAttachment = std::make_unique<juce::SliderParameterAttachment>(
         *valueTreeState.getParameter(ParameterIds::vcfEgDepth), vcfEgDepthSlider);
+
+    // Set up filter type monitoring
+    auto* filterTypeParam = valueTreeState.getParameter(ParameterIds::filterType);
+    filterTypeAttachment = std::make_unique<juce::ParameterAttachment>(
+        *filterTypeParam,
+        [this](float value) { updateResonanceControl(value); },
+        valueTreeState.undoManager);
+    
+    // Set initial state
+    updateResonanceControl(filterTypeParam->getValue());
 }
 
 VCFComponent::~VCFComponent() {}
@@ -38,6 +55,80 @@ void VCFComponent::paint(juce::Graphics& g)
     g.drawFittedText("VCF", getLocalBounds(), juce::Justification::centredTop, 1);
 }
 
+void VCFComponent::updateResonanceControl(float filterType)
+{
+    // filterType 0 = CS01, 1 = Modern
+    if (static_cast<int>(filterType) == 0)
+    {
+        // CS01 mode: Show toggle button
+        resonanceButton.setVisible(true);
+        resonanceLabel.setVisible(true);
+        resonanceSlider.setVisible(false);
+        resonanceSliderLabel.setVisible(false);
+        
+        // Set up attachment
+        if (!resonanceAttachment)
+        {
+            auto* param = valueTreeState.getParameter(ParameterIds::resonance);
+            if (param != nullptr)
+            {
+                // Use standard ButtonParameterAttachment
+                // Button ON = 1.0f, OFF = 0.0f mapping
+                resonanceAttachment = std::make_unique<juce::ButtonParameterAttachment>(
+                    *param, resonanceButton);
+                
+                // Set button's initial state (ON if 0.5 or higher)
+                resonanceButton.setToggleState(param->getValue() >= 0.5f, juce::dontSendNotification);
+            }
+        }
+        if (resonanceSliderAttachment)
+        {
+            resonanceSliderAttachment.reset();
+        }
+    }
+    else
+    {
+        // Modern mode: Show slider
+        resonanceButton.setVisible(false);
+        resonanceLabel.setVisible(false);
+        resonanceSlider.setVisible(true);
+        resonanceSliderLabel.setVisible(true);
+        
+        // Set up attachment
+        if (!resonanceSliderAttachment)
+        {
+            resonanceSliderAttachment = std::make_unique<juce::SliderParameterAttachment>(
+                *valueTreeState.getParameter(ParameterIds::resonance), resonanceSlider);
+        }
+        if (resonanceAttachment)
+        {
+            resonanceAttachment.reset();
+        }
+    }
+}
+
+// Update UI when filter processor changes
+void VCFComponent::updateFilterControl(IFilter* filterProcessor)
+{
+    if (filterProcessor != nullptr)
+    {
+        // Get resonance control type from IFilter
+        auto controlType = filterProcessor->getResonanceMode();
+        
+        // Update UI based on control type
+        if (controlType == IFilter::ResonanceMode::Toggle)
+        {
+            // CS01 filter: Show toggle button
+            updateResonanceControl(0.0f); // Set to CS01 mode (0)
+        }
+        else // Continuous
+        {
+            // Modern filter: Show slider
+            updateResonanceControl(1.0f); // Set to Modern mode (1)
+        }
+    }
+}
+
 void VCFComponent::resized()
 {
     juce::Grid grid;
@@ -47,14 +138,49 @@ void VCFComponent::resized()
     grid.templateRows    = { Track(Fr(5)), Track(Fr(1)) }; // Make slider area taller
     grid.templateColumns = { Track(Fr(1)), Track(Fr(1)), Track(Fr(1)) };
 
+    // Use standard grid item layout and adjust resonance controls later
     grid.items = {
         juce::GridItem(cutoffSlider),
-        juce::GridItem(resonanceButton),
+        // Placeholder for resonance control position (custom placement later)
+        juce::GridItem(),
         juce::GridItem(vcfEgDepthSlider),
+        
         juce::GridItem(cutoffLabel),
-        juce::GridItem(resonanceLabel),
+        // Placeholder for resonance label position
+        juce::GridItem(),
         juce::GridItem(vcfEgDepthLabel)
     };
     
     grid.performLayout(getLocalBounds().reduced(10).withTrimmedTop(20));
+    
+    // Manually place resonance-related UI after applying grid layout
+    auto bounds = getLocalBounds().reduced(10).withTrimmedTop(20);
+    
+    // Calculate column sizes
+    int columnWidth = bounds.getWidth() / 3;
+    int rowHeight = bounds.getHeight() * 5 / 6; // First row is 5/6 of the total height
+    int labelHeight = bounds.getHeight() / 6;   // Label row is 1/6 of the total height
+    
+    // Get the area for the second column (resonance column)
+    juce::Rectangle<int> resonanceArea(
+        bounds.getX() + columnWidth,
+        bounds.getY(),
+        columnWidth,
+        rowHeight
+    );
+    
+    // Position resonance controls
+    resonanceButton.setBounds(resonanceArea);
+    resonanceSlider.setBounds(resonanceArea);
+    
+    // Position resonance labels
+    juce::Rectangle<int> resonanceLabelArea(
+        bounds.getX() + columnWidth,
+        bounds.getY() + rowHeight,
+        columnWidth,
+        labelHeight
+    );
+    
+    resonanceLabel.setBounds(resonanceLabelArea);
+    resonanceSliderLabel.setBounds(resonanceLabelArea);
 }

--- a/Source/UI/VCFComponent.h
+++ b/Source/UI/VCFComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <JuceHeader.h>
+#include "../Parameters.h"
+#include "../CS01Synth/IFilter.h"
 
 class VCFComponent : public juce::Component
 {
@@ -8,17 +10,33 @@ public:
     ~VCFComponent() override;
     void paint(juce::Graphics& g) override;
     void resized() override;
+    
+    // Update UI when filter processor changes
+    void updateFilterControl(IFilter* filterProcessor);
 private:
+    // Method to monitor filter type changes and update resonance UI
+    void updateResonanceControl(float filterType);
+
     juce::AudioProcessorValueTreeState& valueTreeState;
+    
     juce::Slider cutoffSlider;
     juce::Label cutoffLabel;
     std::unique_ptr<juce::SliderParameterAttachment> cutoffAttachment;
 
+    // Toggle button for CS01 filter resonance
     juce::ToggleButton resonanceButton;
     juce::Label resonanceLabel;
     std::unique_ptr<juce::ButtonParameterAttachment> resonanceAttachment;
 
+    // Slider for Modern filter resonance
+    juce::Slider resonanceSlider;
+    juce::Label resonanceSliderLabel;
+    std::unique_ptr<juce::SliderParameterAttachment> resonanceSliderAttachment;
+
     juce::Slider vcfEgDepthSlider;
     juce::Label vcfEgDepthLabel;
     std::unique_ptr<juce::SliderParameterAttachment> vcfEgDepthAttachment;
+
+    // Attachment to monitor filter type parameter changes
+    std::unique_ptr<juce::ParameterAttachment> filterTypeAttachment;
 };

--- a/Tests/CMakeLists.txt
+++ b/Tests/CMakeLists.txt
@@ -42,7 +42,7 @@ target_sources(CheapSynth01Tests
         mocks/MockToneGenerator.h
         unit/IG02610LPFTest.cpp
         unit/ToneGeneratorTest.cpp
-        unit/CS01VCFProcessorTest.cpp
+        unit/OriginalVCFProcessorTest.cpp
         unit/VCAProcessorTest.cpp
         unit/EGProcessorTest.cpp
         unit/LFOProcessorTest.cpp
@@ -60,7 +60,7 @@ target_sources(CheapSynth01Tests
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/ProgramManager.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/IG02610LPF.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/ToneGenerator.cpp
-        ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/CS01VCFProcessor.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/OriginalVCFProcessor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/VCAProcessor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/EGProcessor.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/../Source/CS01Synth/LFOProcessor.cpp

--- a/Tests/unit/OriginalVCFProcessorTest.cpp
+++ b/Tests/unit/OriginalVCFProcessorTest.cpp
@@ -1,11 +1,11 @@
 #include <JuceHeader.h>
-#include "../../Source/CS01Synth/CS01VCFProcessor.h"
+#include "../../Source/CS01Synth/OriginalVCFProcessor.h"
 #include "../../Source/Parameters.h"
 
-class CS01VCFProcessorTest : public juce::UnitTest
+class OriginalVCFProcessorTest : public juce::UnitTest
 {
 public:
-    CS01VCFProcessorTest() : juce::UnitTest("CS01VCFProcessor Tests") {}
+    OriginalVCFProcessorTest() : juce::UnitTest("OriginalVCFProcessor Tests") {}
     
     void runTest() override
     {
@@ -22,7 +22,7 @@ private:
     {
         juce::AudioProcessorValueTreeState::ParameterLayout layout;
         
-        // Add parameters needed for CS01VCFProcessor
+        // Add parameters needed for OriginalVCFProcessor
         layout.add(std::make_unique<juce::AudioParameterFloat>(
             ParameterIds::cutoff, "Cutoff", 
             juce::NormalisableRange<float>(20.0f, 20000.0f, 0.01f, 0.3f), 1000.0f));
@@ -60,14 +60,14 @@ private:
         juce::UndoManager undoManager;
         juce::AudioProcessorValueTreeState apvts(*dummyProcessor, &undoManager, "PARAMETERS", std::move(parameterLayout));
         
-        // Create CS01VCFProcessor
-        std::unique_ptr<CS01VCFProcessor> processor = std::make_unique<CS01VCFProcessor>(apvts);
+        // Create OriginalVCFProcessor
+        std::unique_ptr<OriginalVCFProcessor> processor = std::make_unique<OriginalVCFProcessor>(apvts);
         
         // Check that processor was created successfully
         expect(processor != nullptr);
         
         // Check that processor has expected properties
-        expectEquals(processor->getName(), juce::String("VCF"));
+        expectEquals(processor->getName(), juce::String("Original VCF"));
         expect(!processor->acceptsMidi());
         expect(!processor->producesMidi());
         expect(!processor->isMidiEffect());
@@ -93,8 +93,8 @@ private:
         juce::UndoManager undoManager;
         juce::AudioProcessorValueTreeState apvts(*dummyProcessor, &undoManager, "PARAMETERS", std::move(parameterLayout));
         
-        // Create CS01VCFProcessor
-        std::unique_ptr<CS01VCFProcessor> processor = std::make_unique<CS01VCFProcessor>(apvts);
+        // Create OriginalVCFProcessor
+        std::unique_ptr<OriginalVCFProcessor> processor = std::make_unique<OriginalVCFProcessor>(apvts);
         
         // Test cutoff parameter
         auto* cutoffParam = apvts.getParameter(ParameterIds::cutoff);
@@ -141,8 +141,8 @@ private:
         juce::UndoManager undoManager;
         juce::AudioProcessorValueTreeState apvts(*dummyProcessor, &undoManager, "PARAMETERS", std::move(parameterLayout));
         
-        // Create CS01VCFProcessor
-        std::unique_ptr<CS01VCFProcessor> processor = std::make_unique<CS01VCFProcessor>(apvts);
+        // Create OriginalVCFProcessor
+        std::unique_ptr<OriginalVCFProcessor> processor = std::make_unique<OriginalVCFProcessor>(apvts);
         
         // Test supported buses layout
         juce::AudioProcessor::BusesLayout supportedLayout;
@@ -186,8 +186,8 @@ private:
         juce::UndoManager undoManager;
         juce::AudioProcessorValueTreeState apvts(*dummyProcessor, &undoManager, "PARAMETERS", std::move(parameterLayout));
         
-        // Create CS01VCFProcessor
-        std::unique_ptr<CS01VCFProcessor> processor = std::make_unique<CS01VCFProcessor>(apvts);
+        // Create OriginalVCFProcessor
+        std::unique_ptr<OriginalVCFProcessor> processor = std::make_unique<OriginalVCFProcessor>(apvts);
         
         // Prepare processor
         processor->prepareToPlay(44100.0, 512);
@@ -277,8 +277,8 @@ private:
         juce::UndoManager undoManager;
         juce::AudioProcessorValueTreeState apvts(*dummyProcessor, &undoManager, "PARAMETERS", std::move(parameterLayout));
         
-        // Create CS01VCFProcessor
-        std::unique_ptr<CS01VCFProcessor> processor = std::make_unique<CS01VCFProcessor>(apvts);
+        // Create OriginalVCFProcessor
+        std::unique_ptr<OriginalVCFProcessor> processor = std::make_unique<OriginalVCFProcessor>(apvts);
         
         // Prepare processor
         processor->prepareToPlay(44100.0, 512);
@@ -354,4 +354,4 @@ private:
     }
 };
 
-static CS01VCFProcessorTest cs01VCFProcessorTest;
+static OriginalVCFProcessorTest originalVCFProcessorTest;


### PR DESCRIPTION
…ate filter naming

- Renamed CS01VCFProcessor to OriginalVCFProcessor for clarity
- Created IFilter interface with ResonanceMode to distinguish filter types
- Updated UI to use 'Original' and 'Modern' instead of 'CS01' and 'MODERN'
- Adjusted preset files with appropriate resonance values for Modern filter
- ModernVCFProcessor now supports continuous resonance values with slider