### PR TITLE
Add CLAP plugin format support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,6 +45,7 @@ jobs:
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/Standalone/*
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/VST3/*
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/LV2/*
+            ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/CLAP/*
             
       - name: Package for Release
         if: github.ref_type == 'tag'
@@ -54,6 +55,7 @@ jobs:
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-linux-standalone.zip Standalone/
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-linux-vst3.zip VST3/
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-linux-lv2.zip LV2/
+          zip -r ${{github.workspace}}/release-packages/cheapsynth01-linux-clap.zip CLAP/
           
       - name: Upload Release Packages
         if: github.ref_type == 'tag'
@@ -96,6 +98,7 @@ jobs:
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/VST3/*
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/AU/*
             ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/LV2/*
+            ${{github.workspace}}/build/CheapSynth01_artefacts/${{ env.BUILD_TYPE }}/CLAP/*
             
       - name: Package for Release
         if: github.ref_type == 'tag'
@@ -106,6 +109,7 @@ jobs:
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-macos-vst3.zip VST3/
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-macos-au.zip AU/
           zip -r ${{github.workspace}}/release-packages/cheapsynth01-macos-lv2.zip LV2/
+          zip -r ${{github.workspace}}/release-packages/cheapsynth01-macos-clap.zip CLAP/
           
       - name: Upload Release Packages
         if: github.ref_type == 'tag'

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "libs/clap-juce-extensions"]
+	path = libs/clap-juce-extensions
+	url = https://github.com/free-audio/clap-juce-extensions.git
+	branch = main

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,9 @@ endif()
 # Include JUCE modules
 include(cmake/JUCE.cmake)
 
+# Add CLAP JUCE extensions
+add_subdirectory(libs/clap-juce-extensions EXCLUDE_FROM_ALL)
+
 # Compiler settings
 set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
@@ -37,6 +40,8 @@ else()
     if(NOT WIN32 OR UNIX)
         list(APPEND PLUGIN_FORMATS LV2)
     endif()
+    
+    message(STATUS "Building with plugin formats: ${PLUGIN_FORMATS}")
 endif()
 
 # JUCE plugin settings
@@ -168,6 +173,17 @@ target_link_juce_modules(CheapSynth01)
 target_link_libraries(CheapSynth01 PUBLIC CheapSynth01Resources)
 
 message(STATUS "CheapSynth01 configuration complete!")
+
+# Add CLAP plugin support (only when not building standalone only)
+if(NOT STANDALONE_ONLY)
+    clap_juce_extensions_plugin(TARGET CheapSynth01
+        CLAP_ID "com.yasuyukibaba.cheapsynth01"
+        CLAP_FEATURES instrument synthesizer vintage analog
+        CLAP_MANUAL_URL "https://github.com/yasuyuki-baba/cheapsynth01"
+        CLAP_SUPPORT_URL "https://github.com/yasuyuki-baba/cheapsynth01/issues"
+    )
+    message(STATUS "CLAP plugin target added: CheapSynth01_CLAP")
+endif()
 
 # Add Tests directory
 add_subdirectory(Tests)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,15 +45,46 @@ Feature requests are welcome! Use our feature request template to submit your id
 
 ### Build Instructions
 
+#### First Time Setup
+
+If you've cloned the repository, initialize the submodules:
+
 ```bash
-# Create and configure build directory
+git submodule update --init --recursive
+```
+
+#### Development Build (Fast)
+
+For development, we recommend using the `-DSTANDALONE_ONLY=ON` option to reduce build times:
+
+```bash
+# Create and configure build directory (standalone only)
 cmake -B build -DSTANDALONE_ONLY=ON
 
 # Build the project
 cmake --build build
 ```
 
-For development, we recommend using the `-DSTANDALONE_ONLY=ON` option to reduce build times.
+This builds only the standalone application, which is sufficient for most development and testing.
+
+#### Release Build (All Formats)
+
+To build all plugin formats including CLAP:
+
+```bash
+# Create and configure build directory (all formats)
+cmake -B build -DSTANDALONE_ONLY=OFF
+
+# Build the project
+cmake --build build
+```
+
+This builds all supported plugin formats:
+- Standalone application
+- VST3
+- AU (macOS only)
+- LV2 (macOS and Linux only)
+- CLAP (CLever Audio Plugin)
 
 ### Running Tests
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ The architecture supports real-time parameter changes, allowing for expressive p
 - VST3
 - AU (macOS only)
 - LV2 (macOS and Linux only)
+- CLAP (CLever Audio Plugin)
 
 ## Build Instructions
 

--- a/cmake/JUCE.cmake
+++ b/cmake/JUCE.cmake
@@ -7,7 +7,7 @@ include(FetchContent)
 FetchContent_Declare(
     JUCE
     GIT_REPOSITORY https://github.com/juce-framework/JUCE.git
-    GIT_TAG 8.0.8  # Use latest version (improved compatibility with macOS 15)
+    GIT_TAG 8.0.8  # Latest stable version
 )
 
 # Make JUCE available


### PR DESCRIPTION
- Add clap-juce-extensions as submodule
- Update CMakeLists.txt to include CLAP format
- Update documentation (README.md, CONTRIBUTING.md)
- Update GitHub Actions to build and package CLAP
- CLAP plugin successfully builds and installs