### PR TITLE
Improve master volume state handling

### DIFF
--- a/Source/ProgramManager.h
+++ b/Source/ProgramManager.h
@@ -54,12 +54,17 @@ class ProgramManager {
     std::vector<Program> allPresets; // Combined list for easy access
     int currentProgram = 0;
 
-    // 特定パラメータをステート保存から除外
-    const std::vector<juce::String> stateExcludedParameters = {
+    // プリセット読み込み時に除外するパラメータ（音量変化を防ぐため）
+    const std::vector<juce::String> presetExcludedParameters = {
         ParameterIds::breathInput, ParameterIds::volume, ParameterIds::modDepth,
         ParameterIds::pitchBend};
 
-    bool isStateExcludedParameter(const juce::String& paramId) const;
+    // DAWセッション保存時に除外するパラメータ（リアルタイム入力系のみ）
+    const std::vector<juce::String> sessionExcludedParameters = {
+        ParameterIds::breathInput, ParameterIds::pitchBend, ParameterIds::modDepth};
+
+    bool isSessionExcludedParameter(const juce::String& paramId) const;
+    bool isPresetExcludedParameter(const juce::String& paramId) const;
 
     void initializePresets();
     void loadPresetFromBinaryData(const juce::String& filename);

--- a/Tests/unit/ProgramManagerTest.cpp
+++ b/Tests/unit/ProgramManagerTest.cpp
@@ -211,12 +211,13 @@ TEST_F(ProgramManagerTest, ExcludedParameters)
     float restoredNormalParam = apvts.getParameter(ParameterIds::waveType)->getValue();
     EXPECT_NEAR(restoredNormalParam, 0.5f, 0.01f) << "Normal parameter should be restored";
     
-    // Verify excluded parameters are not restored (should remain at 0.1f)
+    // Verify session excluded parameters are not restored (should remain at 0.1f)
+    // Volume is now included in DAW session state, so it should be restored to 0.8f
     float restoredVolume = apvts.getParameter(ParameterIds::volume)->getValue();
     float restoredBreath = apvts.getParameter(ParameterIds::breathInput)->getValue();
     float restoredPitchBend = apvts.getParameter(ParameterIds::pitchBend)->getValue();
     
-    EXPECT_NEAR(restoredVolume, 0.1f, 0.01f) << "Volume should not be restored";
+    EXPECT_NEAR(restoredVolume, 0.8f, 0.01f) << "Volume should be restored in DAW session state";
     EXPECT_NEAR(restoredBreath, 0.1f, 0.01f) << "Breath input should not be restored";
     EXPECT_NEAR(restoredPitchBend, 0.1f, 0.01f) << "Pitch bend should not be restored";
 }


### PR DESCRIPTION
- Separate parameter exclusion logic for preset loading vs DAW session state
- Master volume now excluded from preset changes but included in DAW sessions
- Add presetExcludedParameters for preset operations (includes volume)
- Add sessionExcludedParameters for DAW state operations (excludes volume)
- This provides better UX: volume stays consistent during preset changes but is saved/restored in DAW projects