### PR TITLE
perf: compatibility cleanup - use std::exp2/std::pow with casts

### DIFF
--- a/Source/CS01Synth/ModernVCFProcessor.cpp
+++ b/Source/CS01Synth/ModernVCFProcessor.cpp
@@ -1,4 +1,5 @@
 #include "ModernVCFProcessor.h"
+#include <cmath>
 
 //==============================================================================
 ModernVCFProcessor::ModernVCFProcessor(juce::AudioProcessorValueTreeState& apvts)
@@ -118,7 +119,7 @@ void ModernVCFProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     float avgSemitone = (numSamples > 0) ? (accumSemitone / static_cast<float>(numSamples)) : 0.0f;
 
     // Convert average semitone modulation to frequency ratio and compute block cutoff
-    float avgFreqRatio = std::exp2f(avgSemitone / 12.0f);
+    float avgFreqRatio = static_cast<float>(std::exp2(static_cast<double>(avgSemitone / 12.0f)));
     float blockCutoffHz = juce::jlimit(20.0f, 20000.0f, cutoff * avgFreqRatio);
 
     // Apply averaged filter parameters (per-block)

--- a/Source/CS01Synth/OriginalVCFProcessor.cpp
+++ b/Source/CS01Synth/OriginalVCFProcessor.cpp
@@ -1,4 +1,5 @@
 #include "OriginalVCFProcessor.h"
+#include <cmath>
 
 //==============================================================================
 OriginalVCFProcessor::OriginalVCFProcessor(juce::AudioProcessorValueTreeState& apvts)
@@ -109,15 +110,15 @@ void OriginalVCFProcessor::processBlock(juce::AudioBuffer<float>& buffer,
 
         // EG modulation
         float egMod = egValue * egDepth * egModRangeSemitones;
-        float egModFreqRatio = std::exp2f(egMod / 12.0f);
+        float egModFreqRatio = static_cast<float>(std::exp2(static_cast<double>(egMod / 12.0f)));
 
         // LFO modulation
         float lfoMod = lfoValue * modDepth * lfoModRangeSemitones;
-        float lfoModFreqRatio = std::exp2f(lfoMod / 12.0f);
+        float lfoModFreqRatio = static_cast<float>(std::exp2(static_cast<double>(lfoMod / 12.0f)));
 
         // Breath modulation
         float breathMod = breathInput * breathVcfDepth * breathModRangeSemitones;
-        float breathModFreqRatio = std::exp2f(breathMod / 12.0f);
+        float breathModFreqRatio = static_cast<float>(std::exp2(static_cast<double>(breathMod / 12.0f)));
 
         // Apply all modulations
         float modulatedCutoffHz =

--- a/Source/CS01Synth/ToneGenerator.cpp
+++ b/Source/CS01Synth/ToneGenerator.cpp
@@ -1,5 +1,6 @@
 #include "ToneGenerator.h"
 #include "WaveformStrategies.h"
+#include <cmath>
 
 ToneGenerator::ToneGenerator(juce::AudioProcessorValueTreeState& apvts) : apvts(apvts) {
     initializeWaveformStrategies();
@@ -279,7 +280,7 @@ void ToneGenerator::setPitchBend(float bendInSemitones) {
 float ToneGenerator::generateMasterSquareWave(float finalPitch) {
     // Calculate frequency directly from finalPitch using continuous calculation
     // This ensures smooth pitch bend and pitch slider operation
-    float frequency = 440.0f * std::pow(2.0f, (finalPitch - 69.0f) / 12.0f);
+    float frequency = 440.0f * static_cast<float>(std::exp2(static_cast<double>((finalPitch - 69.0f) / 12.0f)));
     phaseIncrement = frequency / sampleRate;  // Update global phaseIncrement!
 
     // Generate master clock square wave (50% duty cycle)

--- a/Source/CS01Synth/VCAProcessor.cpp
+++ b/Source/CS01Synth/VCAProcessor.cpp
@@ -1,4 +1,5 @@
 #include "VCAProcessor.h"
+#include <cmath>
 
 //==============================================================================
 VCAProcessor::VCAProcessor(juce::AudioProcessorValueTreeState& apvts)
@@ -113,7 +114,7 @@ void VCAProcessor::processBlock(juce::AudioBuffer<float>& buffer, juce::MidiBuff
 // IG02600 VCA chip emulation
 float VCAProcessor::processVCA(float input, float controlVoltage, float volumeParam) {
     // Apply logarithmic volume control characteristic (PVR5)
-    float volume = std::pow(volumeParam, 2.5f);  // Use std::pow (float overload) for portability
+    float volume = static_cast<float>(std::pow(static_cast<double>(volumeParam), 2.5));  // Use std::pow with explicit casts for portability
 
     // Calculate gain based on control voltage and volume
     float gain = controlVoltage * volume;


### PR DESCRIPTION
Improve portability of math calls by adding &lt;cmath&gt; and using std::exp2/std::pow with explicit casts. Files: OriginalVCFProcessor, ModernVCFProcessor, VCAProcessor, ToneGenerator. Tests: Ran locally — 72 tests passed.