### PR TITLE
fix: remove unused variable in ModernVCFProcessor

### DIFF
--- a/Source/CS01Synth/ModernVCFProcessor.cpp
+++ b/Source/CS01Synth/ModernVCFProcessor.cpp
@@ -91,7 +91,6 @@ void ModernVCFProcessor::processBlock(juce::AudioBuffer<float>& buffer,
     }
 
     processingBuffer.copyFrom(0, 0, audioData, buffer.getNumSamples());
-    float* samples = processingBuffer.getWritePointer(0);
 
     // Compute average modulation in semitones across the block to allow block processing.
     // This reduces per-sample filter coefficient updates while keeping modulation behaviour


### PR DESCRIPTION
Remove unused variable; no behavior change; tests pass.